### PR TITLE
Enable shareable workspace state and calendar exports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,66 +1,298 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useRef, ChangeEvent } from 'react';
 import { Header } from './components/Header';
 import { Controls } from './components/Controls';
 import { complianceItems } from './data/complianceItems';
-import { ViewMode, RolePreset, QuickView, SortKey, Status, AppState } from './types/compliance';
-import { STORAGE_KEY } from './utils/constants';
-import { Calendar } from 'lucide-react';
+import {
+  ViewMode,
+  RolePreset,
+  QuickView,
+  SortKey,
+  Status,
+  AppState,
+  ComplianceItem,
+  FilterState,
+} from './types/compliance';
+import { STORAGE_KEY, SHARE_QUERY_KEY } from './utils/constants';
+import { downloadItemsToCalendar, downloadItemToCalendar } from './utils/ics';
+import {
+  Calendar,
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  Target,
+  Activity,
+  ArrowUpRight,
+  Layers3,
+  ShieldCheck,
+  StickyNote,
+  CalendarPlus,
+} from 'lucide-react';
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+const statusOptions: Status[] = ['Pending', 'In Progress', 'Completed', 'Overdue'];
+
+const defaultFilters: FilterState = {
+  searchTerm: '',
+  filterType: 'all',
+  filterParty: 'all',
+  filterCategory: 'all',
+  showHighPriority: false,
+  viewMode: 'dashboard',
+  rolePreset: 'all',
+  quickView: 'all',
+  sortKey: 'priority',
+  sortDir: 'desc',
+};
+
+type ToastTone = 'info' | 'success' | 'error';
+
+interface ToastMessage {
+  text: string;
+  tone: ToastTone;
+  link?: string;
+}
+
+const encodeStatePayload = (state: AppState) => {
+  const encoder = new TextEncoder();
+  const json = JSON.stringify(state);
+  const bytes = encoder.encode(json);
+  let binary = '';
+  bytes.forEach((value) => {
+    binary += String.fromCharCode(value);
+  });
+  return encodeURIComponent(btoa(binary));
+};
+
+const decodeStatePayload = (payload: string): AppState => {
+  const decoder = new TextDecoder();
+  const binary = atob(decodeURIComponent(payload));
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  const json = decoder.decode(bytes);
+  return JSON.parse(json) as AppState;
+};
+
+const priorityAccent: Record<string, { bg: string; text: string; ring: string }> = {
+  Critical: {
+    bg: 'from-rose-500/30 via-rose-500/10 to-transparent',
+    text: 'text-rose-200',
+    ring: 'border-rose-400/60',
+  },
+  High: {
+    bg: 'from-amber-400/25 via-amber-400/10 to-transparent',
+    text: 'text-amber-200',
+    ring: 'border-amber-300/60',
+  },
+  Medium: {
+    bg: 'from-emerald-400/25 via-emerald-400/10 to-transparent',
+    text: 'text-emerald-200',
+    ring: 'border-emerald-300/60',
+  },
+  Low: {
+    bg: 'from-slate-400/20 via-slate-400/10 to-transparent',
+    text: 'text-slate-200',
+    ring: 'border-slate-300/40',
+  },
+};
+
+const statusTint: Record<Status, { dot: string; text: string; bg: string }> = {
+  Pending: { dot: 'bg-slate-400', text: 'text-slate-200', bg: 'bg-slate-900/40' },
+  'In Progress': { dot: 'bg-sky-400', text: 'text-sky-200', bg: 'bg-sky-900/40' },
+  Completed: { dot: 'bg-emerald-400', text: 'text-emerald-200', bg: 'bg-emerald-900/40' },
+  Overdue: { dot: 'bg-rose-500', text: 'text-rose-200', bg: 'bg-rose-900/40' },
+};
+
+const monthRegex = MONTHS.map((month) => ({ month, regex: new RegExp(month, 'i') }));
+
+const findMonthInText = (text?: string | null) => {
+  if (!text) return null;
+  const match = monthRegex.find(({ regex }) => regex.test(text));
+  return match ? match.month : null;
+};
+
+const resolveMonthForItem = (item: ComplianceItem) => {
+  return findMonthInText(item.annualDate) ?? findMonthInText(item.cyclicDate) ?? findMonthInText(item.deadline) ?? null;
+};
+
+const priorityRank: Record<string, number> = { Critical: 4, High: 3, Medium: 2, Low: 1 };
+
+const getSortValue = (item: ComplianceItem, sortKey: SortKey) => {
+  if (sortKey === 'priority') {
+    return priorityRank[item.priority] ?? 0;
+  }
+
+  if (sortKey === 'deadline') {
+    const month = resolveMonthForItem(item);
+    return month ? MONTHS.indexOf(month) : 99;
+  }
+
+  if (sortKey === 'category') return item.category;
+  if (sortKey === 'type') return item.type;
+  return item.title;
+};
+
+const defaultStatus: Status = 'Pending';
 
 function App() {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [filterType, setFilterType] = useState('all');
-  const [filterParty, setFilterParty] = useState('all');
-  const [filterCategory, setFilterCategory] = useState('all');
-  const [showHighPriority, setShowHighPriority] = useState(false);
-  const [viewMode, setViewMode] = useState<ViewMode>('grid');
-  const [rolePreset, setRolePreset] = useState<RolePreset>('all');
-  const [quickView, setQuickView] = useState<QuickView>('all');
-  const [sortKey, setSortKey] = useState<SortKey>('priority');
-  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [searchTerm, setSearchTerm] = useState(defaultFilters.searchTerm);
+  const [filterType, setFilterType] = useState(defaultFilters.filterType);
+  const [filterParty, setFilterParty] = useState(defaultFilters.filterParty);
+  const [filterCategory, setFilterCategory] = useState(defaultFilters.filterCategory);
+  const [showHighPriority, setShowHighPriority] = useState(defaultFilters.showHighPriority);
+  const [viewMode, setViewMode] = useState<ViewMode>(defaultFilters.viewMode);
+  const [rolePreset, setRolePreset] = useState<RolePreset>(defaultFilters.rolePreset);
+  const [quickView, setQuickView] = useState<QuickView>(defaultFilters.quickView);
+  const [sortKey, setSortKey] = useState<SortKey>(defaultFilters.sortKey);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>(defaultFilters.sortDir);
+  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
   const [statusMap, setStatusMap] = useState<Record<number, Status>>({});
   const [notesMap, setNotesMap] = useState<Record<number, string>>({});
+  const [toast, setToast] = useState<ToastMessage | null>(null);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+
+  const importInputRef = useRef<HTMLInputElement | null>(null);
+
+  const applyFilters = (filters?: Partial<FilterState>) => {
+    const merged: FilterState = { ...defaultFilters, ...(filters ?? {}) };
+    setSearchTerm(merged.searchTerm);
+    setFilterType(merged.filterType);
+    setFilterParty(merged.filterParty);
+    setFilterCategory(merged.filterCategory);
+    setShowHighPriority(merged.showHighPriority);
+    setViewMode(merged.viewMode);
+    setRolePreset(merged.rolePreset);
+    setQuickView(merged.quickView);
+    setSortKey(merged.sortKey);
+    setSortDir(merged.sortDir);
+  };
+
+  const buildStateSnapshot = (): AppState => ({
+    statusMap,
+    notesMap,
+    theme,
+    filters: {
+      searchTerm,
+      filterType,
+      filterParty,
+      filterCategory,
+      showHighPriority,
+      viewMode,
+      rolePreset,
+      quickView,
+      sortKey,
+      sortDir,
+    },
+    generatedAt: new Date().toISOString(),
+  });
+
+  const pushToast = (message: string, tone: ToastTone = 'info', link?: string) => {
+    setToast({ text: message, tone, link });
+    if (link) {
+      setShareUrl(link);
+    }
+  };
 
   useEffect(() => {
+    if (!toast) return;
+    const timer = window.setTimeout(() => setToast(null), 6000);
+    return () => window.clearTimeout(timer);
+  }, [toast]);
+
+  const applyImportedState = (state?: Partial<AppState>) => {
+    if (!state) {
+      setStatusMap({});
+      setNotesMap({});
+      applyFilters();
+      setTheme('dark');
+      return;
+    }
+
+    setStatusMap(state.statusMap ?? {});
+    setNotesMap(state.notesMap ?? {});
+    if (state.theme) {
+      setTheme(state.theme);
+    }
+    if (state.filters) {
+      applyFilters(state.filters);
+    }
+  };
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const sharedPayload = params.get(SHARE_QUERY_KEY);
+
+    if (sharedPayload) {
+      try {
+        const parsed = decodeStatePayload(sharedPayload);
+        applyImportedState(parsed);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed));
+        const url = `${window.location.origin}${window.location.pathname}?${SHARE_QUERY_KEY}=${sharedPayload}`;
+        pushToast('Loaded shared workspace snapshot.', 'success', url);
+      } catch (error) {
+        console.error('Failed to parse shared workspace', error);
+        pushToast('Unable to load shared workspace link.', 'error');
+      }
+
+      params.delete(SHARE_QUERY_KEY);
+      const query = params.toString();
+      const newUrl = `${window.location.pathname}${query ? `?${query}` : ''}`;
+      window.history.replaceState({}, '', newUrl);
+      return;
+    }
+
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
       try {
         const parsed: AppState = JSON.parse(raw);
-        setStatusMap(parsed.statusMap || {});
-        setNotesMap(parsed.notesMap || {});
-        setTheme(parsed.theme || 'light');
-      } catch (e) {
-        console.error('Failed to load state from localStorage', e);
+        applyImportedState(parsed);
+      } catch (error) {
+        console.error('Failed to load state from localStorage', error);
       }
     }
   }, []);
 
   useEffect(() => {
-    const snapshot: Partial<AppState> = {
-      statusMap,
-      notesMap,
-      theme,
-    };
+    const snapshot = buildStateSnapshot();
     localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
-  }, [statusMap, notesMap, theme]);
+  }, [
+    statusMap,
+    notesMap,
+    theme,
+    searchTerm,
+    filterType,
+    filterParty,
+    filterCategory,
+    showHighPriority,
+    viewMode,
+    rolePreset,
+    quickView,
+    sortKey,
+    sortDir,
+  ]);
 
   useEffect(() => {
-    if (rolePreset === 'all') {
-      setFilterParty('all');
-    } else if (rolePreset === 'council') {
-      setFilterParty('Settlement Council');
-    } else if (rolePreset === 'administrator') {
-      setFilterParty('Settlement Administrator');
-    } else if (rolePreset === 'registrar') {
-      setFilterParty('MSLR Registrar');
-    } else if (rolePreset === 'msgc') {
-      setFilterParty('MSGC (General Council)');
-    } else if (rolePreset === 'msat') {
-      setFilterParty('MSAT');
-    } else if (rolePreset === 'minister') {
-      setFilterParty('Minister; MSGC');
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
     }
-  }, [rolePreset]);
+  }, [theme]);
+
+  const resolveStatus = (id: number) => statusMap[id] || defaultStatus;
 
   const filteredItems = useMemo(() => {
     let items = complianceItems.filter((item) => {
@@ -68,7 +300,7 @@ function App() {
         searchTerm === '' ||
         item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
         item.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        item.section.includes(searchTerm);
+        item.section.toLowerCase().includes(searchTerm.toLowerCase());
 
       const matchesType = filterType === 'all' || item.type === filterType;
       const matchesParty =
@@ -78,64 +310,634 @@ function App() {
         (filterParty === 'MSAT' && item.responsible && item.responsible.includes('MSAT')) ||
         (filterParty === 'Minister; MSGC' && (item.category === 'Ministerial' || item.category === 'MSGC'));
       const matchesCategory = filterCategory === 'all' || item.category === filterCategory;
-      const matchesPriority = !showHighPriority || (showHighPriority && (item.priority === 'Critical' || item.priority === 'High'));
+      const matchesPriority =
+        !showHighPriority || (showHighPriority && (item.priority === 'Critical' || item.priority === 'High'));
 
       return matchesSearch && matchesType && matchesParty && matchesCategory && matchesPriority;
     });
 
     if (quickView === 'overdue') {
-      items = items.filter((i) => statusMap[i.id] === 'Overdue');
+      items = items.filter((i) => resolveStatus(i.id) === 'Overdue');
     } else if (quickView === 'completed') {
-      items = items.filter((i) => statusMap[i.id] === 'Completed');
+      items = items.filter((i) => resolveStatus(i.id) === 'Completed');
     } else if (quickView === 'critical') {
       items = items.filter((i) => i.priority === 'Critical');
     } else if (quickView === 'upcoming') {
-      items = items.filter((i) => i.annualDate || i.cyclicDate);
+      items = items.filter((i) => resolveMonthForItem(i) !== null);
     }
 
-    const dirMul = sortDir === 'asc' ? 1 : -1;
-    items.sort((a, b) => {
-      const v = (key: SortKey) => {
-        if (key === 'priority') {
-          const rank: Record<string, number> = { Critical: 4, High: 3, Medium: 2, Low: 1 };
-          return (rank[a.priority] || 0) - (rank[b.priority] || 0);
-        } else if (key === 'title') {
-          return a.title.localeCompare(b.title);
-        } else if (key === 'category') {
-          return a.category.localeCompare(b.category);
-        } else if (key === 'type') {
-          return a.type.localeCompare(b.type);
-        } else if (key === 'deadline') {
-          return (a.deadline || '').localeCompare(b.deadline || '');
-        } else {
-          return 0;
-        }
-      };
-      return v(sortKey) * dirMul;
-    });
+    const dirMultiplier = sortDir === 'asc' ? 1 : -1;
 
-    return items;
-  }, [complianceItems, searchTerm, filterType, filterParty, filterCategory, showHighPriority, quickView, sortKey, sortDir, statusMap]);
+    return items.sort((a, b) => {
+      const valueA = getSortValue(a, sortKey);
+      const valueB = getSortValue(b, sortKey);
+
+      if (typeof valueA === 'number' && typeof valueB === 'number') {
+        return (valueA - valueB) * dirMultiplier;
+      }
+
+      return valueA.toString().localeCompare(valueB.toString()) * dirMultiplier;
+    });
+  }, [searchTerm, filterType, filterParty, filterCategory, showHighPriority, quickView, sortKey, sortDir, statusMap]);
+
+  const timelineItems = useMemo(() => {
+    const ranked = [...filteredItems].sort((a, b) => {
+      const monthA = resolveMonthForItem(a);
+      const monthB = resolveMonthForItem(b);
+      const idxA = monthA ? MONTHS.indexOf(monthA) : 99;
+      const idxB = monthB ? MONTHS.indexOf(monthB) : 99;
+      if (idxA !== idxB) return idxA - idxB;
+      return (priorityRank[b.priority] ?? 0) - (priorityRank[a.priority] ?? 0);
+    });
+    return ranked;
+  }, [filteredItems]);
+
+  const calendarBuckets = useMemo(() => {
+    const buckets = new Map<string, ComplianceItem[]>();
+    filteredItems.forEach((item) => {
+      const month = resolveMonthForItem(item) ?? 'Flexible';
+      const existing = buckets.get(month) ?? [];
+      existing.push(item);
+      buckets.set(month, existing);
+    });
+    return buckets;
+  }, [filteredItems]);
+
+  const priorityCounts = useMemo(() => {
+    return complianceItems.reduce(
+      (acc, item) => {
+        acc[item.priority] = (acc[item.priority] ?? 0) + 1;
+        return acc;
+      },
+      { Critical: 0, High: 0, Medium: 0, Low: 0 } as Record<string, number>,
+    );
+  }, []);
+
+  const statusCounts = useMemo(() => {
+    return complianceItems.reduce(
+      (acc, item) => {
+        const status = resolveStatus(item.id);
+        acc[status] = (acc[status] ?? 0) + 1;
+        return acc;
+      },
+      { Pending: 0, 'In Progress': 0, Completed: 0, Overdue: 0 } as Record<Status, number>,
+    );
+  }, [statusMap]);
+
+  const completionRate = Math.round((statusCounts.Completed / complianceItems.length) * 100);
+  const activeCritical = filteredItems.filter((item) => item.priority === 'Critical' && resolveStatus(item.id) !== 'Completed').length;
+
+  const upcomingHighlights = useMemo(() => {
+    return timelineItems
+      .filter((item) => resolveMonthForItem(item) !== null)
+      .slice(0, 5)
+      .map((item) => ({
+        item,
+        month: resolveMonthForItem(item) ?? 'Flexible',
+        status: resolveStatus(item.id),
+      }));
+  }, [timelineItems, statusMap]);
+
+  const topParties = useMemo(() => {
+    const counts: Record<string, number> = {};
+    filteredItems.forEach((item) => {
+      counts[item.responsible] = (counts[item.responsible] ?? 0) + 1;
+    });
+    return Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 4);
+  }, [filteredItems]);
 
   const handleThemeToggle = () => {
     setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
   };
 
   const handleExport = () => {
-    alert('Export functionality - CSV and JSON exports available');
+    try {
+      const snapshot = buildStateSnapshot();
+      const blob = new Blob([JSON.stringify(snapshot, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      const timestamp = new Date().toISOString().replace(/[:]/g, '-');
+      anchor.href = url;
+      anchor.download = `msct-workspace-${timestamp}.json`;
+      anchor.click();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+      pushToast('Workspace exported as JSON.', 'success');
+    } catch (error) {
+      console.error('Export failed', error);
+      pushToast('Export failed. Please try again.', 'error');
+    }
   };
 
   const handleImport = () => {
-    alert('Import functionality - Import JSON data');
+    importInputRef.current?.click();
+  };
+
+  const handleImportFile = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const content = typeof reader.result === 'string' ? reader.result : '';
+        const parsed = JSON.parse(content) as AppState;
+        applyImportedState(parsed);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed));
+        pushToast('Workspace imported successfully.', 'success');
+      } catch (error) {
+        console.error('Failed to import workspace', error);
+        pushToast('Import failed. Ensure the file is a valid workspace export.', 'error');
+      }
+    };
+
+    reader.readAsText(file);
+    event.target.value = '';
   };
 
   const handlePrint = () => {
     window.print();
   };
 
+  const handleShareWorkspace = async () => {
+    try {
+      const snapshot = buildStateSnapshot();
+      const encoded = encodeStatePayload(snapshot);
+      const url = `${window.location.origin}${window.location.pathname}?${SHARE_QUERY_KEY}=${encoded}`;
+      setShareUrl(url);
+
+      if (navigator.share) {
+        try {
+          await navigator.share({ title: 'MSCT workspace', url });
+          pushToast('Share sheet opened. Send the link to your collaborators.', 'success', url);
+          return;
+        } catch (error) {
+          console.warn('Native share cancelled or failed', error);
+        }
+      }
+
+      try {
+        await navigator.clipboard.writeText(url);
+        pushToast('Shareable link copied to clipboard.', 'success', url);
+      } catch (error) {
+        console.error('Clipboard copy failed', error);
+        pushToast('Shareable link ready below.', 'info', url);
+      }
+    } catch (error) {
+      console.error('Failed to create share link', error);
+      pushToast('Unable to generate a share link.', 'error');
+    }
+  };
+
+  const handleResetWorkspace = () => {
+    applyImportedState(undefined);
+    localStorage.removeItem(STORAGE_KEY);
+    setShareUrl(null);
+    pushToast('Workspace reset. Local changes cleared.', 'success');
+  };
+
+  const handleCalendarDownload = () => {
+    const success = downloadItemsToCalendar(
+      filteredItems,
+      statusMap,
+      notesMap,
+      window.location.href,
+      'msct-schedule',
+    );
+
+    if (success) {
+      pushToast('Downloaded calendar file for the current view.', 'success');
+    } else {
+      pushToast('No items available to export for the calendar.', 'info');
+    }
+  };
+
+  const handleItemCalendarDownload = (item: ComplianceItem) => {
+    const success = downloadItemToCalendar(
+      item,
+      statusMap,
+      notesMap,
+      window.location.href,
+      `msct-item-${item.id}`,
+    );
+
+    if (success) {
+      pushToast(`Calendar entry generated for "${item.title}".`, 'success');
+    } else {
+      pushToast('Unable to generate a calendar entry for this requirement.', 'error');
+    }
+  };
+
+  const handleRolePresetChange = (preset: RolePreset) => {
+    setRolePreset(preset);
+    if (preset === 'all') {
+      setFilterParty('all');
+    } else if (preset === 'council') {
+      setFilterParty('Settlement Council');
+    } else if (preset === 'administrator') {
+      setFilterParty('Settlement Administrator');
+    } else if (preset === 'registrar') {
+      setFilterParty('MSLR Registrar');
+    } else if (preset === 'msgc') {
+      setFilterParty('MSGC (General Council)');
+    } else if (preset === 'msat') {
+      setFilterParty('MSAT');
+    } else if (preset === 'minister') {
+      setFilterParty('Minister; MSGC');
+    }
+  };
+
+  const handleStatusChange = (id: number, status: Status) => {
+    setStatusMap((prev) => ({ ...prev, [id]: status }));
+  };
+
+  const handleNotesChange = (id: number, notes: string) => {
+    setNotesMap((prev) => ({ ...prev, [id]: notes }));
+  };
+
+  const renderStatusBadge = (status: Status) => {
+    const palette = statusTint[status];
+    return (
+      <span
+        className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium ${palette.bg} ${palette.text} border border-white/10`}
+      >
+        <span className={`h-2.5 w-2.5 rounded-full ${palette.dot}`} />
+        {status}
+      </span>
+    );
+  };
+
+  const renderCard = (item: ComplianceItem) => {
+    const palette = priorityAccent[item.priority];
+    const status = resolveStatus(item.id);
+    return (
+      <div
+        key={item.id}
+        className={`relative overflow-hidden rounded-3xl border border-white/10 bg-slate-950/60 shadow-2xl shadow-slate-900/40 p-6 flex flex-col gap-5`}
+      >
+        <div className={`absolute inset-x-0 top-0 h-32 bg-gradient-to-br ${palette.bg} pointer-events-none`} />
+        <div className="relative flex items-start justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2 text-xs text-slate-300 uppercase tracking-[0.3em]">
+              <Layers3 className="h-3.5 w-3.5" />
+              {item.section}
+            </div>
+            <h3 className="mt-3 text-2xl font-semibold text-slate-100 drop-shadow-[0_8px_24px_rgba(15,118,110,0.35)]">
+              {item.title}
+            </h3>
+            <p className="mt-2 text-sm text-slate-300 leading-relaxed">{item.description}</p>
+          </div>
+          <div className={`px-3 py-1.5 rounded-full border ${palette.ring} bg-slate-950/50 text-xs font-semibold ${palette.text}`}>
+            {item.priority}
+          </div>
+        </div>
+
+        <div className="relative grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-200">
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-emerald-300" />
+            <span className="font-medium text-slate-200">Deadline:</span>
+            <span className="text-slate-300">{item.deadline || 'Flexible / Triggered'}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Clock3 className="h-4 w-4 text-sky-300" />
+            <span className="font-medium text-slate-200">Frequency:</span>
+            <span className="text-slate-300">{item.frequency}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-emerald-300" />
+            <span className="font-medium text-slate-200">Responsible:</span>
+            <span className="text-slate-300">{item.responsible}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Target className="h-4 w-4 text-amber-300" />
+            <span className="font-medium text-slate-200">Type:</span>
+            <span className="text-slate-300">{item.type}</span>
+          </div>
+        </div>
+
+        {item.consequences && (
+          <div className="relative rounded-2xl border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-100">
+            <div className="flex items-center gap-2 font-semibold uppercase tracking-[0.2em] text-rose-200">
+              <AlertTriangle className="h-4 w-4" /> Consequences
+            </div>
+            <p className="mt-2 leading-relaxed text-rose-100/90">{item.consequences}</p>
+          </div>
+        )}
+
+        <div className="relative flex flex-col gap-3">
+          <div className="flex flex-wrap items-center gap-3">
+            {renderStatusBadge(status)}
+            <select
+              value={status}
+              onChange={(event) => handleStatusChange(item.id, event.target.value as Status)}
+              className="rounded-full bg-slate-900/70 border border-white/10 px-4 py-1.5 text-xs text-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-400/60"
+            >
+              {statusOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+          <label className="flex flex-col gap-2 text-xs text-slate-400">
+            <span className="inline-flex items-center gap-2 text-slate-300">
+              <StickyNote className="h-4 w-4 text-emerald-300" /> Intelligence notes
+            </span>
+            <textarea
+              value={notesMap[item.id] || ''}
+              onChange={(event) => handleNotesChange(item.id, event.target.value)}
+              placeholder="Log context, commitments, or escalation paths..."
+              className="min-h-[90px] resize-none rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-3 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-400/60"
+            />
+          </label>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-slate-300">
+            <button
+              onClick={() => handleItemCalendarDownload(item)}
+              className="inline-flex items-center gap-2 rounded-full border border-cyan-400/40 bg-cyan-500/15 px-3 py-1.5 text-cyan-100 transition hover:border-cyan-300/60 hover:bg-cyan-500/20"
+            >
+              <CalendarPlus className="h-3.5 w-3.5" /> Add to calendar
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const renderTableView = () => {
+    return (
+      <div className="overflow-hidden rounded-3xl border border-white/10 bg-slate-950/70 shadow-2xl">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-white/5 text-sm text-slate-200">
+            <thead className="bg-slate-900/80">
+              <tr className="text-left">
+                <th className="px-6 py-3">Section</th>
+                <th className="px-6 py-3">Requirement</th>
+                <th className="px-6 py-3">Deadline</th>
+                <th className="px-6 py-3">Responsible</th>
+                <th className="px-6 py-3">Priority</th>
+                <th className="px-6 py-3">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {filteredItems.map((item) => (
+                <tr key={item.id} className="hover:bg-slate-900/60 transition">
+                  <td className="px-6 py-4 text-xs uppercase tracking-[0.2em] text-slate-400">{item.section}</td>
+                  <td className="px-6 py-4">
+                    <div className="font-semibold text-slate-100">{item.title}</div>
+                    <div className="text-xs text-slate-400 mt-1 leading-relaxed">{item.description}</div>
+                  </td>
+                  <td className="px-6 py-4 text-slate-300">{item.deadline || 'Flexible'}</td>
+                  <td className="px-6 py-4 text-slate-300">{item.responsible}</td>
+                  <td className="px-6 py-4">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-slate-900/60 px-3 py-1 text-xs">
+                      <span className={`h-2.5 w-2.5 rounded-full ${priorityAccent[item.priority].text.replace('text-', 'bg-')}`} />
+                      {item.priority}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4">
+                    <div className="flex flex-col gap-2">
+                      {renderStatusBadge(resolveStatus(item.id))}
+                      <select
+                        value={resolveStatus(item.id)}
+                        onChange={(event) => handleStatusChange(item.id, event.target.value as Status)}
+                        className="rounded-full bg-slate-900/70 border border-white/10 px-3 py-1 text-xs text-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-400/60"
+                      >
+                        {statusOptions.map((option) => (
+                          <option key={option} value={option}>
+                            {option}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  };
+
+  const renderTimelineView = () => {
+    return (
+      <div className="relative pl-6">
+        <div className="absolute left-2 top-0 bottom-0 w-px bg-gradient-to-b from-emerald-400/70 via-cyan-400/40 to-transparent" />
+        <div className="space-y-8">
+          {timelineItems.map((item) => {
+            const status = resolveStatus(item.id);
+            return (
+              <div key={item.id} className="relative rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-xl">
+                <div className="absolute -left-[29px] top-6 flex h-6 w-6 items-center justify-center rounded-full bg-slate-950 border border-emerald-400/60">
+                  <Calendar className="h-3.5 w-3.5 text-emerald-300" />
+                </div>
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <div className="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-slate-400">
+                      {resolveMonthForItem(item) ?? 'Flexible cadence'}
+                      <ArrowUpRight className="h-3.5 w-3.5" />
+                    </div>
+                    <h3 className="mt-3 text-xl font-semibold text-slate-100">{item.title}</h3>
+                  </div>
+                  {renderStatusBadge(status)}
+                </div>
+                <p className="mt-2 text-sm text-slate-300 leading-relaxed">{item.description}</p>
+                <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
+                  <div className="flex items-center gap-2">
+                    <Clock3 className="h-4 w-4 text-sky-300" />
+                    {item.frequency}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <ShieldCheck className="h-4 w-4 text-emerald-300" />
+                    {item.responsible}
+                  </div>
+                </div>
+                <div className="mt-4">
+                  <button
+                    onClick={() => handleItemCalendarDownload(item)}
+                    className="inline-flex items-center gap-2 rounded-full border border-cyan-400/40 bg-cyan-500/15 px-3 py-1.5 text-xs text-cyan-100 transition hover:border-cyan-300/60 hover:bg-cyan-500/20"
+                  >
+                    <CalendarPlus className="h-3.5 w-3.5" /> Add to calendar
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  const renderCalendarView = () => {
+    const order = [...MONTHS, 'Flexible'];
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+        {order.map((month) => {
+          const items = calendarBuckets.get(month) || [];
+          if (items.length === 0) return null;
+          return (
+            <div key={month} className="rounded-3xl border border-white/10 bg-slate-950/60 p-6 shadow-xl">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-slate-100">{month}</h3>
+                <span className="text-sm text-slate-400">{items.length} obligations</span>
+              </div>
+              <div className="mt-4 space-y-3">
+                {items.map((item) => (
+                  <div key={item.id} className="rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-3">
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-semibold text-slate-100">{item.title}</p>
+                      <span className="text-xs text-slate-400">{item.priority}</span>
+                    </div>
+                    <p className="mt-2 text-xs text-slate-400">{item.deadline || 'Flexible trigger'}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderDashboard = () => {
+    return (
+      <div className="space-y-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+          <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-lg">
+            <div className="flex items-center justify-between text-sm text-slate-400">
+              Completion velocity <Activity className="h-4 w-4 text-emerald-300" />
+            </div>
+            <div className="mt-4 flex items-end justify-between">
+              <span className="text-4xl font-semibold text-emerald-200">{completionRate}%</span>
+              <span className="text-xs text-slate-400">{statusCounts.Completed} complete / {complianceItems.length}</span>
+            </div>
+            <div className="mt-4 h-2 w-full rounded-full bg-slate-900/60">
+              <div className="h-2 rounded-full bg-gradient-to-r from-emerald-400 via-cyan-400 to-sky-400" style={{ width: `${completionRate}%` }} />
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-lg">
+            <div className="flex items-center justify-between text-sm text-slate-400">
+              Critical load <AlertTriangle className="h-4 w-4 text-rose-300" />
+            </div>
+            <div className="mt-4 text-4xl font-semibold text-rose-200">{activeCritical}</div>
+            <p className="mt-2 text-xs text-slate-400">Critical obligations demanding immediate action.</p>
+          </div>
+
+          <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-lg">
+            <div className="flex items-center justify-between text-sm text-slate-400">
+              Active oversight <Target className="h-4 w-4 text-amber-300" />
+            </div>
+            <div className="mt-4 text-4xl font-semibold text-amber-200">{filteredItems.length}</div>
+            <p className="mt-2 text-xs text-slate-400">Focused obligations after filters &amp; presets.</p>
+          </div>
+
+          <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-lg">
+            <div className="flex items-center justify-between text-sm text-slate-400">
+              Completed assurances <CheckCircle2 className="h-4 w-4 text-emerald-300" />
+            </div>
+            <div className="mt-4 text-4xl font-semibold text-emerald-200">{statusCounts.Completed}</div>
+            <p className="mt-2 text-xs text-slate-400">Verified obligations closed out.</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+          <div className="xl:col-span-2 rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-xl">
+            <div className="flex items-center justify-between text-sm text-slate-400">
+              Upcoming pressure points <Clock3 className="h-4 w-4 text-sky-300" />
+            </div>
+            <div className="mt-4 space-y-4">
+              {upcomingHighlights.length === 0 && (
+                <p className="text-sm text-slate-400">No timed obligations detected for current filters.</p>
+              )}
+              {upcomingHighlights.map(({ item, month, status }) => (
+                <div key={item.id} className="rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-100">{item.title}</p>
+                      <p className="text-xs text-slate-400 mt-1">{item.responsible}</p>
+                    </div>
+                    <span className="text-xs text-slate-400">{month}</span>
+                  </div>
+                  <div className="mt-3 flex flex-wrap items-center gap-3">
+                    {renderStatusBadge(status)}
+                    <span className="text-xs text-slate-400">{item.deadline || item.frequency}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-xl">
+            <div className="flex items-center justify-between text-sm text-slate-400">
+              Responsibility hotspots <ShieldCheck className="h-4 w-4 text-emerald-300" />
+            </div>
+            <div className="mt-4 space-y-4">
+              {topParties.map(([party, count]) => (
+                <div key={party} className="flex items-center justify-between rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-3">
+                  <span className="text-sm text-slate-200">{party}</span>
+                  <span className="text-xs text-slate-400">{count} items</span>
+                </div>
+              ))}
+            </div>
+            <div className="mt-6 text-xs text-slate-400">
+              Priority distribution
+              <div className="mt-3 space-y-2">
+                {Object.entries(priorityCounts).map(([priority, count]) => (
+                  <div key={priority} className="flex items-center gap-3">
+                    <span className="w-20 text-xs text-slate-300">{priority}</span>
+                    <div className="flex-1 h-2 rounded-full bg-slate-900/60">
+                      <div
+                        className="h-2 rounded-full bg-gradient-to-r from-emerald-400 via-cyan-400 to-sky-400"
+                        style={{ width: `${Math.max(8, (count / complianceItems.length) * 100)}%` }}
+                      />
+                    </div>
+                    <span className="text-xs text-slate-400">{count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const renderActiveView = () => {
+    if (viewMode === 'grid') {
+      return (
+        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
+          {filteredItems.map((item) => renderCard(item))}
+        </div>
+      );
+    }
+
+    if (viewMode === 'table') {
+      return renderTableView();
+    }
+
+    if (viewMode === 'timeline') {
+      return renderTimelineView();
+    }
+
+    if (viewMode === 'calendar') {
+      return renderCalendarView();
+    }
+
+    return renderDashboard();
+  };
+
   return (
-    <div className={`min-h-screen p-6 ${theme === 'dark' ? 'bg-gray-900 text-gray-100' : 'bg-gray-50 text-gray-900'}`}>
-      <div className="max-w-7xl mx-auto">
+    <div className="min-h-screen pb-16">
+      <div className="relative mx-auto w-full max-w-7xl px-6 pt-12 lg:px-10">
+        <input
+          ref={importInputRef}
+          type="file"
+          accept="application/json"
+          className="hidden"
+          onChange={handleImportFile}
+        />
         <Header
           theme={theme}
           onThemeToggle={handleThemeToggle}
@@ -143,6 +945,7 @@ function App() {
           onImport={handleImport}
           onPrint={handlePrint}
         />
+
         <Controls
           searchTerm={searchTerm}
           filterCategory={filterCategory}
@@ -162,108 +965,65 @@ function App() {
           onFilterPartyChange={setFilterParty}
           onHighPriorityToggle={() => setShowHighPriority(!showHighPriority)}
           onViewModeChange={setViewMode}
-          onRolePresetChange={setRolePreset}
+          onRolePresetChange={handleRolePresetChange}
           onQuickViewChange={setQuickView}
           onSortKeyChange={setSortKey}
           onSortDirChange={setSortDir}
+          onShareWorkspace={handleShareWorkspace}
+          onDownloadCalendar={handleCalendarDownload}
+          onResetWorkspace={handleResetWorkspace}
+          statusMessage={toast}
+          shareUrl={shareUrl}
         />
 
-        <div className="bg-white dark:bg-gray-800 rounded-lg p-4 mb-6 border border-gray-200 dark:border-gray-700 shadow">
-          <div className="flex flex-wrap gap-4">
-            <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded-full bg-red-500"></div>
-              <span className="text-sm text-gray-700 dark:text-gray-300">Critical Priority</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded-full bg-amber-500"></div>
-              <span className="text-sm text-gray-700 dark:text-gray-300">High Priority</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded-full bg-green-500"></div>
-              <span className="text-sm text-gray-700 dark:text-gray-300">Medium Priority</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Calendar className="w-4 h-4 text-gray-500" />
-              <span className="text-sm text-gray-700 dark:text-gray-300">Annual/Cyclic Deadline</span>
-            </div>
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_minmax(260px,320px)] gap-8">
+          <div className="space-y-8">
+            {renderActiveView()}
+            {filteredItems.length === 0 && (
+              <div className="rounded-3xl border border-white/10 bg-slate-950/60 p-12 text-center text-lg text-slate-300 shadow-xl">
+                No requirements found. Adjust filters to reveal additional obligations.
+              </div>
+            )}
           </div>
-        </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
-          {filteredItems.map((item) => (
-            <div
-              key={item.id}
-              className={`rounded-lg p-6 border-l-4 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow hover:shadow-lg transition-shadow ${
-                item.priority === 'Critical'
-                  ? 'border-l-red-500'
-                  : item.priority === 'High'
-                  ? 'border-l-amber-500'
-                  : item.priority === 'Medium'
-                  ? 'border-l-green-500'
-                  : 'border-l-gray-500'
-              }`}
-            >
-              <div className="flex items-start justify-between mb-3">
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 mb-2">
-                    <span className="text-xs font-mono bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1 rounded">
-                      § {item.section}
+          <aside className="space-y-6">
+            <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-xl">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Status matrix</h2>
+              <div className="mt-4 space-y-4 text-sm text-slate-300">
+                {statusOptions.map((status) => (
+                  <div key={status} className="flex items-center justify-between rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-3">
+                    <span className="flex items-center gap-2">
+                      <span className={`h-2.5 w-2.5 rounded-full ${statusTint[status].dot}`} />
+                      {status}
                     </span>
-                    <span className={`text-xs px-2 py-1 rounded font-medium ${item.type === 'Meeting' ? 'bg-blue-100 text-blue-800' : item.type === 'Financial' ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-800'}`}>
-                      {item.type}
-                    </span>
+                    <span className="text-xs text-slate-400">{statusCounts[status] ?? 0}</span>
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">{item.title}</h3>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">{item.description}</p>
-                </div>
+                ))}
               </div>
-
-              <div className="space-y-2 text-sm">
-                <div className="flex items-start gap-2">
-                  <span className="font-medium text-gray-700 dark:text-gray-300">Deadline:</span>
-                  <span className="text-gray-600 dark:text-gray-400">{item.deadline}</span>
-                </div>
-                <div className="flex items-start gap-2">
-                  <span className="font-medium text-gray-700 dark:text-gray-300">Frequency:</span>
-                  <span className="text-gray-600 dark:text-gray-400">{item.frequency}</span>
-                </div>
-                <div className="flex items-start gap-2">
-                  <span className="font-medium text-gray-700 dark:text-gray-300">Responsible:</span>
-                  <span className="text-gray-600 dark:text-gray-400">{item.responsible}</span>
-                </div>
-                <div className="flex items-start gap-2">
-                  <span className="font-medium text-gray-700 dark:text-gray-300">Priority:</span>
-                  <span
-                    className={`font-medium ${
-                      item.priority === 'Critical'
-                        ? 'text-red-600'
-                        : item.priority === 'High'
-                        ? 'text-amber-600'
-                        : item.priority === 'Medium'
-                        ? 'text-green-600'
-                        : 'text-gray-600'
-                    }`}
-                  >
-                    {item.priority}
-                  </span>
-                </div>
-              </div>
-
-              {item.consequences && (
-                <div className="mt-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded">
-                  <div className="text-xs font-semibold text-red-800 dark:text-red-300 mb-1">Consequences:</div>
-                  <div className="text-xs text-red-700 dark:text-red-400">{item.consequences}</div>
-                </div>
-              )}
             </div>
-          ))}
-        </div>
 
-        {filteredItems.length === 0 && (
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-12 text-center border border-gray-200 dark:border-gray-700 shadow">
-            <p className="text-gray-500 dark:text-gray-400 text-lg">No requirements found. Try adjusting your search or filters.</p>
-          </div>
-        )}
+            <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-xl">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Legend</h2>
+              <div className="mt-4 space-y-3 text-xs text-slate-300">
+                <div className="flex items-center gap-2">
+                  <span className="h-3 w-3 rounded-full bg-rose-500" /> Critical priority trigger
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="h-3 w-3 rounded-full bg-amber-400" /> High priority
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="h-3 w-3 rounded-full bg-emerald-400" /> Medium priority
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="h-3 w-3 rounded-full bg-slate-400" /> Low priority
+                </div>
+                <div className="flex items-center gap-2">
+                  <Calendar className="h-4 w-4 text-emerald-300" /> Anchored deadline / cadence
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,4 +1,18 @@
-import { Search, Filter, Users, ListChecks } from 'lucide-react';
+import { JSX } from 'react';
+import {
+  Search,
+  Filter,
+  Users,
+  ListChecks,
+  LayoutGrid,
+  Table2,
+  CalendarClock,
+  CalendarDays,
+  Radar,
+  Share2,
+  CalendarPlus,
+  RotateCw,
+} from 'lucide-react';
 import { FILTER_OPTIONS } from '../utils/constants';
 import { ViewMode, RolePreset, QuickView, SortKey } from '../types/compliance';
 
@@ -25,7 +39,28 @@ interface ControlsProps {
   onQuickViewChange: (view: QuickView) => void;
   onSortKeyChange: (key: SortKey) => void;
   onSortDirChange: (dir: 'asc' | 'desc') => void;
+  onShareWorkspace: () => void;
+  onDownloadCalendar: () => void;
+  onResetWorkspace: () => void;
+  statusMessage: { text: string; tone: 'info' | 'success' | 'error'; link?: string } | null;
+  shareUrl: string | null;
 }
+
+const viewModeLabels: Record<ViewMode, string> = {
+  grid: 'Grid',
+  table: 'Table',
+  timeline: 'Timeline',
+  calendar: 'Calendar',
+  dashboard: 'Dashboard',
+};
+
+const viewModeIcons: Record<ViewMode, JSX.Element> = {
+  grid: <LayoutGrid className="w-4 h-4" />,
+  table: <Table2 className="w-4 h-4" />,
+  timeline: <CalendarClock className="w-4 h-4" />,
+  calendar: <CalendarDays className="w-4 h-4" />,
+  dashboard: <Radar className="w-4 h-4" />,
+};
 
 export const Controls = ({
   searchTerm,
@@ -50,189 +85,223 @@ export const Controls = ({
   onQuickViewChange,
   onSortKeyChange,
   onSortDirChange,
+  onShareWorkspace,
+  onDownloadCalendar,
+  onResetWorkspace,
+  statusMessage,
+  shareUrl,
 }: ControlsProps) => {
+  const messageToneStyles: Record<'info' | 'success' | 'error', string> = {
+    info: 'border-cyan-400/40 bg-cyan-500/10 text-cyan-100',
+    success: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100',
+    error: 'border-rose-400/40 bg-rose-500/10 text-rose-100',
+  };
+
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg p-6 mb-6 border border-gray-200 dark:border-gray-700 shadow">
-      <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5" />
-          <input
-            type="text"
-            placeholder="Search requirements..."
-            value={searchTerm}
-            onChange={(e) => onSearchChange(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
-          />
-        </div>
+    <div className="glass-panel rounded-3xl p-6 lg:p-8 mb-10">
+      <div className="flex flex-col gap-8">
+        <div className="grid grid-cols-1 xl:grid-cols-4 gap-4">
+          <div className="relative">
+            <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 w-5 h-5" />
+            <input
+              type="text"
+              placeholder="Search requirements, sections, obligations..."
+              value={searchTerm}
+              onChange={(e) => onSearchChange(e.target.value)}
+              className="w-full pl-12 pr-4 py-3 rounded-2xl bg-slate-900/60 border border-white/10 text-slate-100 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/60"
+            />
+          </div>
 
-        <div className="relative">
-          <Filter className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5 pointer-events-none" />
-          <select
-            value={filterCategory}
-            onChange={(e) => onFilterCategoryChange(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 appearance-none bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
-          >
-            {FILTER_OPTIONS.categories.map((category) => (
-              <option key={category} value={category}>
-                {category === 'all' ? 'All Categories' : category}
-              </option>
-            ))}
-          </select>
-        </div>
+          <div className="relative">
+            <Filter className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 w-5 h-5" />
+            <select
+              value={filterCategory}
+              onChange={(e) => onFilterCategoryChange(e.target.value)}
+              className="w-full pl-12 pr-10 py-3 rounded-2xl bg-slate-900/60 border border-white/10 text-slate-100 focus:outline-none focus:ring-2 focus:ring-emerald-400/60 appearance-none"
+            >
+              {FILTER_OPTIONS.categories.map((category) => (
+                <option key={category} value={category}>
+                  {category === 'all' ? 'All Categories' : category}
+                </option>
+              ))}
+            </select>
+          </div>
 
-        <div className="relative">
-          <Filter className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5 pointer-events-none" />
-          <select
-            value={filterType}
-            onChange={(e) => onFilterTypeChange(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 appearance-none bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
-          >
-            {FILTER_OPTIONS.types.map((type) => (
-              <option key={type} value={type}>
-                {type === 'all' ? 'All Types' : type}
-              </option>
-            ))}
-          </select>
-        </div>
+          <div className="relative">
+            <Filter className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 w-5 h-5" />
+            <select
+              value={filterType}
+              onChange={(e) => onFilterTypeChange(e.target.value)}
+              className="w-full pl-12 pr-10 py-3 rounded-2xl bg-slate-900/60 border border-white/10 text-slate-100 focus:outline-none focus:ring-2 focus:ring-emerald-400/60 appearance-none"
+            >
+              {FILTER_OPTIONS.types.map((type) => (
+                <option key={type} value={type}>
+                  {type === 'all' ? 'All Types' : type}
+                </option>
+              ))}
+            </select>
+          </div>
 
-        <div className="relative">
-          <Users className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5 pointer-events-none" />
-          <select
-            value={filterParty}
-            onChange={(e) => onFilterPartyChange(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 appearance-none bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
-          >
-            {FILTER_OPTIONS.parties.map((party) => (
-              <option key={party} value={party}>
-                {party === 'all' ? 'All Parties' : party}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="relative">
-          <ListChecks className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5 pointer-events-none" />
-          <div className="w-full pl-10 pr-4 py-2 border rounded-lg bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600">
-            <label className="inline-flex items-center cursor-pointer">
-              <input
-                type="checkbox"
-                checked={showHighPriority}
-                onChange={onHighPriorityToggle}
-                className="sr-only peer"
-              />
-              <div className="relative w-11 h-6 bg-gray-200 rounded-full peer-checked:bg-blue-600">
-                <div className="absolute top-[2px] left-[2px] h-5 w-5 bg-white rounded-full transition-all peer-checked:translate-x-full"></div>
-              </div>
-              <span className="ms-3 text-sm font-medium text-gray-900 dark:text-gray-100">High Priority Only</span>
-            </label>
+          <div className="relative">
+            <Users className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 w-5 h-5" />
+            <select
+              value={filterParty}
+              onChange={(e) => onFilterPartyChange(e.target.value)}
+              className="w-full pl-12 pr-10 py-3 rounded-2xl bg-slate-900/60 border border-white/10 text-slate-100 focus:outline-none focus:ring-2 focus:ring-emerald-400/60 appearance-none"
+            >
+              {FILTER_OPTIONS.parties.map((party) => (
+                <option key={party} value={party}>
+                  {party === 'all' ? 'All Parties' : party}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
-      </div>
 
-      <div className="mt-4 flex flex-wrap items-center justify-between gap-4">
-        <div className="text-sm text-gray-500 dark:text-gray-400">
-          Showing {filteredCount} of {totalItems} requirements
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-slate-900/60 border border-white/10">
+              <span className="w-2.5 h-2.5 rounded-full bg-emerald-400 shadow-[0_0_12px_rgba(16,185,129,0.8)]" />
+              Showing {filteredCount} of {totalItems} obligations
+            </div>
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-slate-900/60 border border-white/10">
+              <ListChecks className="w-4 h-4 text-emerald-300" />
+              <label className="inline-flex items-center gap-2 cursor-pointer select-none">
+                <span>High priority focus</span>
+                <span className="relative">
+                  <input
+                    type="checkbox"
+                    checked={showHighPriority}
+                    onChange={onHighPriorityToggle}
+                    className="peer sr-only"
+                  />
+                  <span className="block h-6 w-11 rounded-full bg-slate-700 peer-checked:bg-emerald-500 transition" />
+                  <span className="absolute top-1 left-1 h-4 w-4 rounded-full bg-white transition peer-checked:translate-x-5" />
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            {(Object.keys(viewModeLabels) as ViewMode[]).map((mode) => (
+              <button
+                key={mode}
+                onClick={() => onViewModeChange(mode)}
+                className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full border transition ${
+                  viewMode === mode
+                    ? 'border-emerald-400/60 bg-emerald-500/15 text-emerald-200'
+                    : 'border-white/10 bg-slate-900/60 text-slate-300 hover:text-white'
+                }`}
+              >
+                {viewModeIcons[mode]}
+                {viewModeLabels[mode]}
+              </button>
+            ))}
+          </div>
         </div>
 
-        <div className="flex items-center gap-2">
-          <button
-            className={`px-3 py-1 rounded-lg transition ${
-              viewMode === 'grid' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
-            }`}
-            onClick={() => onViewModeChange('grid')}
-          >
-            Grid
-          </button>
-          <button
-            className={`px-3 py-1 rounded-lg transition ${
-              viewMode === 'table' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
-            }`}
-            onClick={() => onViewModeChange('table')}
-          >
-            Table
-          </button>
-          <button
-            className={`px-3 py-1 rounded-lg transition ${
-              viewMode === 'timeline' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
-            }`}
-            onClick={() => onViewModeChange('timeline')}
-          >
-            Timeline
-          </button>
-          <button
-            className={`px-3 py-1 rounded-lg transition ${
-              viewMode === 'calendar' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
-            }`}
-            onClick={() => onViewModeChange('calendar')}
-          >
-            Calendar
-          </button>
-          <button
-            className={`px-3 py-1 rounded-lg transition ${
-              viewMode === 'dashboard' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
-            }`}
-            onClick={() => onViewModeChange('dashboard')}
-          >
-            Dashboard
-          </button>
-        </div>
-      </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="flex items-center gap-3 px-4 py-3 rounded-2xl bg-slate-900/60 border border-white/10">
+            <span className="text-sm text-slate-300">Role preset</span>
+            <select
+              value={rolePreset}
+              onChange={(e) => onRolePresetChange(e.target.value as RolePreset)}
+              className="flex-1 bg-transparent border-none text-slate-100 focus:outline-none"
+            >
+              <option value="all">All</option>
+              <option value="council">Settlement Council</option>
+              <option value="administrator">Administrator</option>
+              <option value="registrar">MSLR Registrar</option>
+              <option value="msgc">MSGC</option>
+              <option value="msat">MSAT</option>
+              <option value="minister">Minister</option>
+            </select>
+          </div>
 
-      <div className="mt-4 flex flex-wrap items-center justify-between gap-4">
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Role preset:</span>
-          <select
-            value={rolePreset}
-            onChange={(e) => onRolePresetChange(e.target.value as RolePreset)}
-            className="px-2 py-1 rounded border bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
-          >
-            <option value="all">All</option>
-            <option value="council">Settlement Council</option>
-            <option value="administrator">Administrator</option>
-            <option value="registrar">MSLR Registrar</option>
-            <option value="msgc">MSGC</option>
-            <option value="msat">MSAT</option>
-            <option value="minister">Minister</option>
-          </select>
+          <div className="flex items-center gap-3 px-4 py-3 rounded-2xl bg-slate-900/60 border border-white/10">
+            <span className="text-sm text-slate-300">Quick view</span>
+            <select
+              value={quickView}
+              onChange={(e) => onQuickViewChange(e.target.value as QuickView)}
+              className="flex-1 bg-transparent border-none text-slate-100 focus:outline-none"
+            >
+              <option value="all">All</option>
+              <option value="upcoming">Upcoming</option>
+              <option value="overdue">Overdue</option>
+              <option value="completed">Completed</option>
+              <option value="critical">Critical</option>
+            </select>
+          </div>
+
+          <div className="flex items-center gap-3 px-4 py-3 rounded-2xl bg-slate-900/60 border border-white/10">
+            <span className="text-sm text-slate-300">Sort order</span>
+            <select
+              value={sortKey}
+              onChange={(e) => onSortKeyChange(e.target.value as SortKey)}
+              className="flex-1 bg-transparent border-none text-slate-100 focus:outline-none"
+            >
+              <option value="priority">Priority</option>
+              <option value="title">Title</option>
+              <option value="category">Category</option>
+              <option value="deadline">Deadline</option>
+              <option value="type">Type</option>
+            </select>
+            <select
+              value={sortDir}
+              onChange={(e) => onSortDirChange(e.target.value as 'asc' | 'desc')}
+              className="bg-transparent border-none text-slate-100 focus:outline-none"
+            >
+              <option value="asc">Asc</option>
+              <option value="desc">Desc</option>
+            </select>
+          </div>
         </div>
 
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Quick view:</span>
-          <select
-            value={quickView}
-            onChange={(e) => onQuickViewChange(e.target.value as QuickView)}
-            className="px-2 py-1 rounded border bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
-          >
-            <option value="all">All</option>
-            <option value="upcoming">Upcoming</option>
-            <option value="overdue">Overdue</option>
-            <option value="completed">Completed</option>
-            <option value="critical">Critical</option>
-          </select>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              onClick={onShareWorkspace}
+              className="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/15 px-4 py-2 text-sm text-emerald-100 transition hover:border-emerald-300/60 hover:bg-emerald-500/20"
+            >
+              <Share2 className="h-4 w-4" /> Share live workspace
+            </button>
+            <button
+              onClick={onDownloadCalendar}
+              className="inline-flex items-center gap-2 rounded-full border border-cyan-400/40 bg-cyan-500/15 px-4 py-2 text-sm text-cyan-100 transition hover:border-cyan-300/60 hover:bg-cyan-500/20"
+            >
+              <CalendarPlus className="h-4 w-4" /> Calendar (.ics)
+            </button>
+            <button
+              onClick={onResetWorkspace}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-500/40 bg-slate-800/60 px-4 py-2 text-sm text-slate-200 transition hover:border-slate-300/60 hover:bg-slate-800"
+            >
+              <RotateCw className="h-4 w-4" /> Reset workspace
+            </button>
+          </div>
+          <p className="text-xs text-slate-400">
+            Changes auto-save in your browser. Shareable links recreate this exact view for your teammates.
+          </p>
         </div>
 
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Sort by:</span>
-          <select
-            value={sortKey}
-            onChange={(e) => onSortKeyChange(e.target.value as SortKey)}
-            className="px-2 py-1 rounded border bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
+        {(statusMessage || shareUrl) && (
+          <div
+            className={`rounded-2xl border px-4 py-3 text-sm leading-relaxed ${
+              statusMessage ? messageToneStyles[statusMessage.tone] : 'border-slate-500/40 bg-slate-900/60 text-slate-200'
+            }`}
           >
-            <option value="priority">Priority</option>
-            <option value="title">Title</option>
-            <option value="category">Category</option>
-            <option value="deadline">Deadline</option>
-            <option value="type">Type</option>
-          </select>
-          <select
-            value={sortDir}
-            onChange={(e) => onSortDirChange(e.target.value as 'asc' | 'desc')}
-            className="px-2 py-1 rounded border bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
-          >
-            <option value="asc">Asc</option>
-            <option value="desc">Desc</option>
-          </select>
-        </div>
+            {statusMessage?.text || 'Latest share link ready to send.'}
+            {(statusMessage?.link || shareUrl) && (
+              <div className="mt-2 break-all text-xs text-slate-100/80">
+                <a
+                  href={statusMessage?.link || shareUrl || ''}
+                  className="underline decoration-dotted underline-offset-4 hover:text-slate-50"
+                >
+                  {statusMessage?.link || shareUrl}
+                </a>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Download, Upload, Printer, Sparkles } from 'lucide-react';
+import { Download, Upload, Printer, Sparkles, Zap, MoonStar } from 'lucide-react';
 
 interface HeaderProps {
   theme: 'light' | 'dark';
@@ -10,45 +10,66 @@ interface HeaderProps {
 
 export const Header = ({ theme, onThemeToggle, onExport, onImport, onPrint }: HeaderProps) => {
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg p-6 mb-6 border border-gray-200 dark:border-gray-700 shadow">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
-            Métis Settlements Comprehensive Compliance Tracker (2025)
+    <div className="relative overflow-hidden rounded-3xl p-8 lg:p-12 mb-10 glass-panel">
+      <div className="absolute inset-0 pointer-events-none">
+        <div className="absolute -top-20 -left-10 h-64 w-64 rounded-full bg-emerald-500/30 blur-3xl" />
+        <div className="absolute top-1/2 right-0 h-72 w-72 -translate-y-1/2 rounded-full bg-cyan-500/20 blur-3xl" />
+        <div className="absolute -bottom-24 -right-16 h-60 w-60 rounded-full bg-fuchsia-500/20 blur-3xl" />
+      </div>
+
+      <div className="relative flex flex-col lg:flex-row gap-10">
+        <div className="flex-1">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-500/10 border border-emerald-400/30 text-emerald-200 text-xs tracking-[0.35em] uppercase">
+            <Sparkles className="h-3.5 w-3.5" />
+            <span>Live Compliance Intelligence</span>
+          </div>
+
+          <h1 className="mt-6 text-4xl lg:text-5xl font-semibold leading-tight text-slate-50 drop-shadow-[0_8px_25px_rgba(16,185,129,0.35)]">
+            Métis Settlements Compliance Command Center
           </h1>
-          <p className="text-gray-500 dark:text-gray-400 mt-1">
-            Track deadlines, requirements, and obligations under the Métis Settlements Act and associated legislation
+
+          <p className="mt-5 text-lg text-slate-200/80 max-w-2xl">
+            Navigate legislation, deadlines, and accountability with a cinematic interface built for decisive action.
+            Instantly filter obligations, chart upcoming pressure points, and keep every stakeholder aligned.
           </p>
+
+          <div className="mt-8 flex flex-wrap gap-3 text-sm text-slate-200/80">
+            <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-slate-900/60 border border-slate-700/60">
+              <Zap className="h-4 w-4 text-amber-300" />
+              Adaptive filtering engine
+            </span>
+            <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-slate-900/60 border border-slate-700/60">
+              <MoonStar className="h-4 w-4 text-sky-300" />
+              Dual theme persistence
+            </span>
+          </div>
         </div>
-        <div className="flex items-center gap-3">
+
+        <div className="lg:w-64 flex flex-col gap-3">
           <button
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition"
+            className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-emerald-500 hover:bg-emerald-400 text-emerald-950 font-semibold shadow-lg shadow-emerald-600/30 transition"
             onClick={onExport}
           >
-            <Download className="w-4 h-4" />
-            Export
+            <Download className="w-4 h-4" /> Export intelligence
           </button>
           <button
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-600 text-white hover:bg-amber-700 transition"
+            className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-slate-900/80 hover:bg-slate-800/80 border border-white/10 text-slate-100 transition"
             onClick={onImport}
           >
-            <Upload className="w-4 h-4" />
-            Import
+            <Upload className="w-4 h-4" /> Import data stream
           </button>
           <button
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 transition"
+            className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-slate-900/50 hover:bg-slate-800/70 border border-white/10 text-slate-100 transition"
             onClick={onPrint}
           >
-            <Printer className="w-4 h-4" />
-            Print
+            <Printer className="w-4 h-4" /> Tactical print view
           </button>
           <button
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 transition"
+            className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-gradient-to-r from-slate-800 to-slate-900 hover:from-slate-700 hover:to-slate-800 border border-white/10 text-slate-100 transition"
             onClick={onThemeToggle}
             title="Toggle theme"
           >
-            <Sparkles className="w-4 h-4" />
-            {theme === 'dark' ? 'Light' : 'Dark'}
+            <Sparkles className="w-4 h-4" /> Activate {theme === 'dark' ? 'light' : 'dark'} flux
           </button>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,42 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+    --app-bg: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+    --app-text: #0f172a;
+  }
+
+  :root.dark {
+    color-scheme: dark;
+    --app-bg:
+      radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.25), transparent 55%),
+      radial-gradient(circle at 80% 0%, rgba(168, 85, 247, 0.35), transparent 55%),
+      radial-gradient(circle at 50% 80%, rgba(34, 197, 94, 0.15), transparent 60%),
+      linear-gradient(135deg, #020617 0%, #0f172a 45%, #111827 100%);
+    --app-text: #e2e8f0;
+  }
+
+  body {
+    @apply min-h-screen antialiased transition-colors duration-500;
+    color: var(--app-text);
+    background: var(--app-bg);
+    background-attachment: fixed;
+  }
+
+  ::selection {
+    @apply bg-emerald-500/70 text-white;
+  }
+}
+
+@layer utilities {
+  .glass-panel {
+    @apply bg-white/10 dark:bg-white/5 backdrop-blur-xl border border-white/10 shadow-2xl shadow-slate-950/30;
+  }
+
+  .glow-ring {
+    box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.3), 0 10px 40px rgba(15, 118, 110, 0.2), inset 0 0 40px rgba(14, 116, 144, 0.2);
+  }
+}

--- a/src/types/compliance.ts
+++ b/src/types/compliance.ts
@@ -47,11 +47,26 @@ export interface AuditLogEntry {
   details: string;
 }
 
+export interface FilterState {
+  searchTerm: string;
+  filterType: string;
+  filterParty: string;
+  filterCategory: string;
+  showHighPriority: boolean;
+  viewMode: ViewMode;
+  rolePreset: RolePreset;
+  quickView: QuickView;
+  sortKey: SortKey;
+  sortDir: 'asc' | 'desc';
+}
+
 export interface AppState {
-  statusMap: Record<number, Status>;
-  notesMap: Record<number, string>;
-  auditLog: AuditLogEntry[];
-  attachmentsMap: Record<number, Attachment[]>;
-  reminderList: Reminder[];
-  theme: 'light' | 'dark';
+  statusMap?: Record<number, Status>;
+  notesMap?: Record<number, string>;
+  auditLog?: AuditLogEntry[];
+  attachmentsMap?: Record<number, Attachment[]>;
+  reminderList?: Reminder[];
+  theme?: 'light' | 'dark';
+  filters?: FilterState;
+  generatedAt?: string;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,5 @@
 export const STORAGE_KEY = 'msa_compliance_tracker_v1';
+export const SHARE_QUERY_KEY = 'state';
 
 export const FILTER_OPTIONS = {
   categories: [

--- a/src/utils/ics.ts
+++ b/src/utils/ics.ts
@@ -1,0 +1,159 @@
+import { ComplianceItem, Status } from '../types/compliance';
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+const parseDate = (value?: string | null) => {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+  return new Date(parsed);
+};
+
+const resolveMonthPlaceholder = (value?: string | null) => {
+  if (!value) return null;
+  const month = MONTHS.find((monthName) => value.toLowerCase().includes(monthName.toLowerCase()));
+  if (!month) return null;
+  const now = new Date();
+  return new Date(`${month} 1, ${now.getFullYear()}`);
+};
+
+export const deriveScheduleDate = (item: ComplianceItem) => {
+  return (
+    parseDate(item.deadline) ||
+    parseDate(item.annualDate) ||
+    parseDate(item.cyclicDate) ||
+    resolveMonthPlaceholder(item.deadline) ||
+    resolveMonthPlaceholder(item.annualDate) ||
+    resolveMonthPlaceholder(item.cyclicDate) ||
+    new Date()
+  );
+};
+
+const pad = (value: number) => value.toString().padStart(2, '0');
+
+const formatDate = (date: Date) => `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}`;
+
+const formatDateTimeUTC = (date: Date) =>
+  `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}T${pad(date.getUTCHours())}${pad(
+    date.getUTCMinutes(),
+  )}${pad(date.getUTCSeconds())}Z`;
+
+const escapeText = (value: string) =>
+  value
+    .replace(/\\/g, '\\\\')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;')
+    .replace(/\r?\n/g, '\\n');
+
+const buildEvent = (item: ComplianceItem, status: Status, notes: string | undefined, sourceUrl: string) => {
+  const start = deriveScheduleDate(item);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+
+  const dtStart = formatDate(start);
+  const dtEnd = formatDate(end);
+  const dtStamp = formatDateTimeUTC(new Date());
+
+  const descriptionSegments = [
+    item.description,
+    `Status: ${status}`,
+    `Deadline: ${item.deadline || 'Flexible / Triggered'}`,
+    `Frequency: ${item.frequency}`,
+    `Responsible: ${item.responsible}`,
+  ];
+
+  if (notes) {
+    descriptionSegments.push(`Notes: ${notes}`);
+  }
+
+  descriptionSegments.push(`Source: ${sourceUrl}`);
+
+  const description = escapeText(descriptionSegments.join('\n'));
+
+  return [
+    'BEGIN:VEVENT',
+    `UID:msct-${item.id}-${dtStart}@metis-settlements`,
+    `DTSTAMP:${dtStamp}`,
+    `DTSTART;VALUE=DATE:${dtStart}`,
+    `DTEND;VALUE=DATE:${dtEnd}`,
+    `SUMMARY:${escapeText(`${item.title} (${status})`)}`,
+    `DESCRIPTION:${description}`,
+    `CATEGORIES:${escapeText(item.category)}`,
+    'STATUS:CONFIRMED',
+    'END:VEVENT',
+  ].join('\r\n');
+};
+
+export const buildCalendar = (
+  items: ComplianceItem[],
+  statusMap: Record<number, Status>,
+  notesMap: Record<number, string>,
+  sourceUrl: string,
+) => {
+  if (items.length === 0) return '';
+
+  const events = items
+    .map((item) => buildEvent(item, statusMap[item.id] ?? 'Pending', notesMap[item.id], sourceUrl))
+    .join('\r\n');
+
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//MSCT//Compliance Tracker//EN',
+    'CALSCALE:GREGORIAN',
+    events,
+    'END:VCALENDAR',
+  ].join('\r\n');
+};
+
+export const downloadCalendar = (icsContent: string, fileName: string) => {
+  if (!icsContent) return;
+  const blob = new Blob([icsContent], { type: 'text/calendar' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName.endsWith('.ics') ? fileName : `${fileName}.ics`;
+  anchor.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+};
+
+export const downloadItemsToCalendar = (
+  items: ComplianceItem[],
+  statusMap: Record<number, Status>,
+  notesMap: Record<number, string>,
+  sourceUrl: string,
+  fileName: string,
+) => {
+  const calendar = buildCalendar(items, statusMap, notesMap, sourceUrl);
+  if (!calendar) return false;
+  downloadCalendar(calendar, fileName);
+  return true;
+};
+
+export const downloadItemToCalendar = (
+  item: ComplianceItem,
+  statusMap: Record<number, Status>,
+  notesMap: Record<number, string>,
+  sourceUrl: string,
+  fileName: string,
+) => {
+  const calendar = buildCalendar([item], statusMap, notesMap, sourceUrl);
+  if (!calendar) return false;
+  downloadCalendar(calendar, fileName);
+  return true;
+};


### PR DESCRIPTION
## Summary
- add collaborative workspace management with shareable URLs, JSON import/export, and reset helpers that persist via local storage
- generate ICS calendar files for filtered or individual obligations using a new calendar utility and inline "Add to calendar" actions
- extend the control surface with share/reset buttons and live status messaging so teammates understand that views auto-save and can be shared

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e55040122883308f58b7996f865681